### PR TITLE
Update build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+CutyCapt
+CutyCapt.o
+Makefile
+moc_CutyCapt.cpp
+moc_CutyCapt.o

--- a/CutyCapt.hpp
+++ b/CutyCapt.hpp
@@ -1,4 +1,6 @@
 #include <QtWebKit>
+#include <QNetworkReply>
+#include <QSslError>
 
 #if QT_VERSION >= 0x050000
 #include <QtWebKitWidgets>

--- a/CutyCapt.pro
+++ b/CutyCapt.pro
@@ -2,6 +2,8 @@ QT       +=  webkit svg network
 SOURCES   =  CutyCapt.cpp
 HEADERS   =  CutyCapt.hpp
 CONFIG   +=  qt console
+target.path = /usr/local/bin/
+INSTALLS += target
 
 greaterThan(QT_MAJOR_VERSION, 4): {
   QT       +=  webkitwidgets


### PR DESCRIPTION
1. Now compiles successfully on Ubuntu. This is directly related to Issue #3. Simply adds two headers to CutyCapt.hpp.
2. Now supports `make install`.
3. Added .gitignore for built output.
