### PR TITLE
Fixes #7

### DIFF
--- a/CutyCapt.pro
+++ b/CutyCapt.pro
@@ -12,3 +12,8 @@ contains(CONFIG, static): {
   DEFINES  += STATIC_PLUGINS
 }
 
+mac {
+  QMAKE_CXXFLAGS += -fvisibility=hidden
+  QMAKE_LFLAGS += '-sectcreate __TEXT __info_plist Info.plist'
+  CONFIG   -= app_bundle
+}

--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist SYSTEM "file://localhost/System/Library/DTDs/PropertyList.dtd">
+<plist version="0.9">
+  <dict>
+    <key>CFBundleExecutable</key>
+    <string>CutyCapt</string>
+    <key>CFBundleIdentifier</key>
+    <string>net.sf.cutycapt</string>
+    <key>LSUIElement</key>
+    <string>1</string>
+  </dict>
+</plist>

--- a/techstack.md
+++ b/techstack.md
@@ -1,0 +1,60 @@
+<!--
+&lt;--- Readme.md Snippet without images Start ---&gt;
+## Tech Stack
+hakanai/CutyCapt is built on the following main stack:
+
+- [C++](http://www.cplusplus.com/) – Languages
+
+Full tech stack [here](/techstack.md)
+
+&lt;--- Readme.md Snippet without images End ---&gt;
+
+&lt;--- Readme.md Snippet with images Start ---&gt;
+## Tech Stack
+hakanai/CutyCapt is built on the following main stack:
+
+- <img width='25' height='25' src='https://img.stackshare.io/service/1049/cplusplus.png' alt='C++'/> [C++](http://www.cplusplus.com/) – Languages
+
+Full tech stack [here](/techstack.md)
+
+&lt;--- Readme.md Snippet with images End ---&gt;
+-->
+<div align="center">
+
+# Tech Stack File
+![](https://img.stackshare.io/repo.svg "repo") [hakanai/CutyCapt](https://github.com/hakanai/CutyCapt)![](https://img.stackshare.io/public_badge.svg "public")
+<br/><br/>
+|2<br/>Tools used|02/11/24 <br/>Report generated|
+|------|------|
+</div>
+
+## <img src='https://img.stackshare.io/languages.svg'/> Languages (1)
+<table><tr>
+  <td align='center'>
+  <img width='36' height='36' src='https://img.stackshare.io/service/1049/cplusplus.png' alt='C++'>
+  <br>
+  <sub><a href="http://www.cplusplus.com/">C++</a></sub>
+  <br>
+  <sub></sub>
+</td>
+
+</tr>
+</table>
+
+## <img src='https://img.stackshare.io/devops.svg'/> DevOps (1)
+<table><tr>
+  <td align='center'>
+  <img width='36' height='36' src='https://img.stackshare.io/service/1046/git.png' alt='Git'>
+  <br>
+  <sub><a href="http://git-scm.com/">Git</a></sub>
+  <br>
+  <sub></sub>
+</td>
+
+</tr>
+</table>
+
+<br/>
+<div align='center'>
+
+Generated via [Stack File](https://github.com/marketplace/stack-file)

--- a/techstack.yml
+++ b/techstack.yml
@@ -1,0 +1,31 @@
+repo_name: hakanai/CutyCapt
+report_id: 14d939518fc3e7b37eee37790d3ed37a
+version: 0.1
+repo_type: Public
+timestamp: '2024-02-11T01:33:58+00:00'
+requested_by: hakanai
+provider: github
+branch: master
+detected_tools_count: 2
+tools:
+- name: C++
+  description: Has imperative, object-oriented and generic programming features, while
+    also providing the facilities for low level memory manipulation
+  website_url: http://www.cplusplus.com/
+  open_source: true
+  hosted_saas: false
+  category: Languages & Frameworks
+  sub_category: Languages
+  image_url: https://img.stackshare.io/service/1049/cplusplus.png
+  detection_source_url: https://github.com/hakanai/CutyCapt
+  detection_source: Repo Metadata
+- name: Git
+  description: Fast, scalable, distributed revision control system
+  website_url: http://git-scm.com/
+  open_source: true
+  hosted_saas: false
+  category: Build, Test, Deploy
+  sub_category: Version Control System
+  image_url: https://img.stackshare.io/service/1046/git.png
+  detection_source_url: https://github.com/hakanai/CutyCapt
+  detection_source: Repo Metadata


### PR DESCRIPTION
Removes the unnecessary app wrapping. Now the only truly awful thing about CutyCapt's resulting executable is that it isn't statically linked, so you need a mess of other Qt libraries and it isn't clear which ones.
